### PR TITLE
added install go to second step

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,7 +20,7 @@ Thank you for your interest in contributing to Hardn! This document outlines the
    cd hardn
    ```
 
-2. **Install dependencies**
+2. **[Install go](https://go.dev/dl/), then add dependencies**
 
    ```bash
    go mod download


### PR DESCRIPTION
The reason I've set the link in the title of second step is because I don't want devs to get distracted finding the proper way to install go(getting lost in goole results, forum threads) for their distro and I do not want to be too invasive, like f.e. introducing a new step.